### PR TITLE
Update google_drive gem to 2.0.0.pre1, google-api-client gem to 0.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
-  - 2.2.2
-  - 2.1.6
-before_install: gem install bundler -v 1.10.5
+  - 2.3.1
+  - 2.2.5
+  - 2.1.10

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ SMTP_PASSWORD=appuser
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'drive_env'
+gem 'drive_env', '~> 0.2.pre1'
 ```
 
 And then execute:
@@ -32,7 +32,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install drive_env
+    $ gem install drive_env --pre
 
 ## Usage
 

--- a/drive_env.gemspec
+++ b/drive_env.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "google_drive", "~> 1.0.1"
-  spec.add_dependency "google-api-client", "~> 0.8.6"
+  spec.add_dependency "google_drive", "~> 2.0.0.pre1"
+  spec.add_dependency "google-api-client", "~> 0.9.6"
   spec.add_dependency "thor", "~> 0.19.1"
   spec.add_dependency "text-table", "~> 1.2.4"
 

--- a/drive_env.gemspec
+++ b/drive_env.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "google_drive", "~> 2.0.0.pre1"
   spec.add_dependency "google-api-client", "~> 0.9.6"
+  spec.add_dependency "googleauth", "~> 0.5.1"
   spec.add_dependency "thor", "~> 0.19.1"
   spec.add_dependency "text-table", "~> 1.2.4"
 

--- a/lib/drive_env.rb
+++ b/lib/drive_env.rb
@@ -1,13 +1,23 @@
 require 'drive_env/version'
-require 'google/api_client'
+require 'googleauth'
+require 'googleauth/stores/file_token_store'
 
 module DriveEnv
   autoload :Cli,     'drive_env/cli'
   autoload :Config,  'drive_env/config'
 
   class << self
-    def client
-      @client ||= Google::APIClient.new(:application_name => 'drive_env', :application_version => DriveEnv::VERSION)
+    def authorizer(client_id, client_secret, token_store_file)
+      unless @authorizer
+        client_id = Google::Auth::ClientId.new(client_id, client_secret)
+        scope = %w[
+          https://www.googleapis.com/auth/drive
+          https://spreadsheets.google.com/feeds/
+        ]
+        token_store = Google::Auth::Stores::FileTokenStore.new(file: token_store_file)
+        @authorizer = Google::Auth::UserAuthorizer.new(client_id, scope, token_store)
+      end
+      @authorizer
     end
   end
 end

--- a/lib/drive_env/config.rb
+++ b/lib/drive_env/config.rb
@@ -4,12 +4,11 @@ require 'yaml'
 module DriveEnv
   class Config
     DEFAULT_CONFIG_FILE = File.expand_path('~/.config/drive_env/config')
+    DEFAULT_TOKENS_STORE_FILE = File.expand_path('~/.config/drive_env/tokens.yml')
+    DEFAULT_TOKEN_USER_ID = 'default'
 
     attr_accessor :client_id
     attr_accessor :client_secret
-    attr_accessor :access_token
-    attr_accessor :refresh_token
-    attr_accessor :expires_at
 
     def initialize
       @spreadsheet_aliases = {}

--- a/lib/drive_env/config.rb
+++ b/lib/drive_env/config.rb
@@ -38,10 +38,20 @@ module DriveEnv
       end
     end
 
+    def migrate
+      ## dropped variables in 0.2.pre1
+      %W[access_token refresh_token expires_at].each do |v|
+        if instance_variable_get("@#{v}")
+          remove_instance_variable("@#{v}")
+        end
+      end
+    end
+
     class << self
       def load(file)
         obj = File.exist?(file) ? YAML.load(File.read(file)) : self.new
         obj.instance_variable_set("@config_file", file)
+        obj.migrate
         obj
       end
     end

--- a/lib/drive_env/version.rb
+++ b/lib/drive_env/version.rb
@@ -1,3 +1,3 @@
 module DriveEnv
-  VERSION = '0.1.0'
+  VERSION = '0.2.pre1'
 end


### PR DESCRIPTION
Updated [google_drive](https://github.com/gimite/google-drive-ruby), [google-api-client](https://github.com/google/google-api-ruby-client) gems,
and use [googleauth](https://github.com/google/google-auth-library-ruby) gem for authorization.

Credentials (access token, refresh token, and expiration time) are stored into ~/.config/drive_env/tokens.yml
(Google::Auth::Stores::FileTokenStore)

```

---
default: '{"client_id":"<CLIENT_ID>","access_token":"<ACCESS_TOKEN>","refresh_token":"<REFRESH_TOKEN>","scope":["https://www.googleapis.com/auth/drive","https://spreadsheets.google.com/feeds/"],"expiration_time_millis":<EXPIRATION_TIME>}'
```
## reviewers
- [x] @akm 
- [x] @nagachika 
