### PR TITLE
Updated gem dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ SMTP_PASSWORD=appuser
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'drive_env', '~> 0.2.pre1'
+gem 'drive_env'
 ```
 
 And then execute:
@@ -32,7 +32,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install drive_env --pre
+    $ gem install drive_env
 
 ## Usage
 

--- a/drive_env.gemspec
+++ b/drive_env.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "google_drive", "~> 2.0.0.pre1"
-  spec.add_dependency "google-api-client", "~> 0.9.6"
+  spec.add_dependency "google_drive", "~> 2.0.1"
+  spec.add_dependency "google-api-client", "~> 0.9.8"
   spec.add_dependency "googleauth", "~> 0.5.1"
   spec.add_dependency "thor", "~> 0.19.1"
   spec.add_dependency "text-table", "~> 1.2.4"

--- a/lib/drive_env/version.rb
+++ b/lib/drive_env/version.rb
@@ -1,3 +1,3 @@
 module DriveEnv
-  VERSION = '0.2.pre1'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
[google_drive gem](https://rubygems.org/gems/google_drive) version 2.0.1 is released.
So updated gem dependencies and bumped version to 0.2.0.
## reviewers
- [x] @akm 
- [x] @nagachika 
