### PR TITLE
Support service account authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Or install it yourself as:
 
 ## Usage
 
-First, you need to login Google Cloud Platform and enable APIs.
+First, you need to login Google Cloud Platform and enable APIs. We support authentication with `User account` and `Service account`.
+
+### User authentication
 
 1. Open [API library page](https://console.developers.google.com/apis/library)
 2. Create/Select project
@@ -55,6 +57,23 @@ $ drive_env auth login
 ```
 
 Now you have access token and refresh token, you can access to Google APIs.
+
+### Service account authentication
+
+1. Open [API library page](https://console.developers.google.com/apis/library)
+2. Create/Select project
+3. Enable "Google Drive API" and "Google Sheets API"
+4. Open [Credentials page](https://console.developers.google.com/apis/credentials) in the same project
+5. Click "Create credentials" and choose "Service account key"
+6. Save credentials as JSON file
+7. Set `GOOGLE_APPLICATION_CREDENTIALS` environment variables with the value of the downloaded JSON file path.
+  ```
+  $ export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service_account_credential.json"
+  ```
+
+The application search `GOOGLE_APPLICATION_CREDENTIALS` first and then try to use user credential.
+
+### Access Spreadsheet
 
 Show Spreadsheet in Google Drive:
 
@@ -99,7 +118,7 @@ $ your-ruby-application-with-dotenv-gem
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake rspec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
@@ -111,4 +130,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/groove
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/drive_env.rb
+++ b/lib/drive_env.rb
@@ -9,13 +9,21 @@ module DriveEnv
   class << self
     def authorizer(client_id, client_secret, token_store_file)
       unless @authorizer
-        client_id = Google::Auth::ClientId.new(client_id, client_secret)
+        cred = ENV['GOOGLE_APPLICATION_CREDENTIALS']
         scope = %w[
           https://www.googleapis.com/auth/drive
           https://spreadsheets.google.com/feeds/
         ]
-        token_store = Google::Auth::Stores::FileTokenStore.new(file: token_store_file)
-        @authorizer = Google::Auth::UserAuthorizer.new(client_id, scope, token_store)
+        if cred.nil?
+          client_id = Google::Auth::ClientId.new(client_id, client_secret)
+          token_store = Google::Auth::Stores::FileTokenStore.new(file: token_store_file)
+          @authorizer = Google::Auth::UserAuthorizer.new(client_id, scope, token_store)
+        else
+          @authorizer = Google::Auth::ServiceAccountCredentials.make_creds(
+            json_key_io: File.open(cred),
+            scope: scope
+          )
+        end
       end
       @authorizer
     end

--- a/lib/drive_env/version.rb
+++ b/lib/drive_env/version.rb
@@ -1,3 +1,3 @@
 module DriveEnv
-  VERSION = '0.3.1'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
# Updates

- Support service account
    - If `GOOGLE_APPLICATION_CREDENTIALS` environment variable is set, use the value. Otherwise same as before.
- Bump version 0.4.0
- Update README

Please confirm and if you find anything, let me know.