### PR TITLE
JSON output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,15 +122,36 @@ JSON output is available by `--format=json` option.
 
 ```
 $ drive_env spreadsheet to_env sheet1 --format=json
-{
-  "RAILS_ENV": "production",
-  "DATABASE_HOSTNAME": "x.x.x.x",
-  "DATABASE_USERNAME": "appuser",
-  "DATABASE_PASSWORD": "appuser",
-  "SMTP_HOST": "x.x.x.x",
-  "SMTP_USERNAME": "appuser",
-  "SMTP_PASSWORD": "appuser"
-}
+[
+  {
+    "key": "RAILS_ENV",
+    "value": "production"
+  },
+  {
+    "key": "DATABASE_HOSTNAME",
+    "value": "x.x.x.x"
+  },
+  {
+    "key": "DATABASE_USERNAME",
+    "value": "appuser"
+  },
+  {
+    "key": "DATABASE_PASSWORD",
+    "value": "appuser"
+  },
+  {
+    "key": "SMTP_HOST",
+    "value": "x.x.x.x"
+  },
+  {
+    "key": "SMTP_USERNAME",
+    "value": "appuser"
+  },
+  {
+    "key": "SMTP_PASSWORD",
+    "value": "appuser"
+  }
+]
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -116,6 +116,23 @@ $ drive_env spreadsheet to_env sheet1 > .env
 $ your-ruby-application-with-dotenv-gem
 ```
 
+#### Output format
+
+JSON output is available by `--format=json` option.
+
+```
+$ drive_env spreadsheet to_env sheet1 --format=json
+{
+  "RAILS_ENV": "production",
+  "DATABASE_HOSTNAME": "x.x.x.x",
+  "DATABASE_USERNAME": "appuser",
+  "DATABASE_PASSWORD": "appuser",
+  "SMTP_HOST": "x.x.x.x",
+  "SMTP_USERNAME": "appuser",
+  "SMTP_PASSWORD": "appuser"
+}
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/drive_env/cli/spreadsheet.rb
+++ b/lib/drive_env/cli/spreadsheet.rb
@@ -24,7 +24,7 @@ module DriveEnv
 
       desc 'to_env SPREADSHEET_URL_OR_ALIAS', ''
       option :format, type: 'string', default: 'dotenv', enum: %w[dotenv json],
-             desc: 'output format (default: dotenv)'
+             desc: 'output format'
       def to_env(url_or_alias)
         ws = worksheet(url_or_alias)
 

--- a/lib/drive_env/cli/spreadsheet.rb
+++ b/lib/drive_env/cli/spreadsheet.rb
@@ -2,6 +2,7 @@ require 'thor'
 require 'text-table'
 require 'google_drive'
 require 'drive_env'
+require 'json'
 
 module DriveEnv
   module Cli
@@ -22,19 +23,34 @@ module DriveEnv
       end
 
       desc 'to_env SPREADSHEET_URL_OR_ALIAS', ''
+      option :format, type: 'string', default: 'dotenv', enum: %w[dotenv json],
+             desc: 'output format (default: dotenv)'
       def to_env(url_or_alias)
         ws = worksheet(url_or_alias)
+
+        envs = []
         ws.rows.each.with_index do |row, idx|
           row_to_env(row) do |key, value, comment|
+            envs << { key: key, value: value, comment: comment }
+          end
+        end
+
+        case options[:format]
+        when 'dotenv'
+          envs.each do |env|
             case
-            when key && value && comment
-              puts "#{key}=#{value} #{comment}"
-            when key && value && !comment
-              puts "#{key}=#{value}"
-            when !key && !value && comment
-              puts comment
+            when env[:key] && env[:value] && env[:comment]
+              puts "#{env[:key]}=#{env[:value]} #{env[:comment]}"
+            when env[:key] && env[:value] && !env[:comment]
+              puts "#{env[:key]}=#{env[:value]}"
+            when !env[:key] && !env[:value] && env[:comment]
+              puts "#{env[:comment]}"
             end
           end
+        when 'json'
+          puts JSON.pretty_generate(
+            Hash[envs.select{|env| env[:key] }.map{|env| [env[:key], env[:value]]}]
+          )
         end
       end
 

--- a/lib/drive_env/cli/spreadsheet.rb
+++ b/lib/drive_env/cli/spreadsheet.rb
@@ -49,7 +49,7 @@ module DriveEnv
           end
         when 'json'
           puts JSON.pretty_generate(
-            Hash[envs.select{|env| env[:key] }.map{|env| [env[:key], env[:value]]}]
+            envs.select{|env| env[:key] }.map{|env| { key: env[:key], value: env[:value] } }
           )
         end
       end

--- a/lib/drive_env/version.rb
+++ b/lib/drive_env/version.rb
@@ -1,3 +1,3 @@
 module DriveEnv
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end


### PR DESCRIPTION
Added `--format` option to `drive_env spreadsheet to_env` command.

```
% drive_env spreadsheet help to_env
Usage:
  drive_env spreadsheet to_env SPREADSHEET_URL_OR_ALIAS

Options:
  [--format=FORMAT]  # output format
                     # Default: dotenv
                     # Possible values: dotenv, json

```

Example output with `--format=json` option.

```console
% drive_env spreadsheet to_env ${SHEET_URL} --format=json
[
  {
    "key": "RAILS_ENV",
    "value": "production"
  },
  {
    "key": "DATABASE_HOSTNAME",
    "value": "x.x.x.x"
  },
  {
    "key": "DATABASE_USERNAME",
    "value": "appuser"
  },
  {
    "key": "DATABASE_PASSWORD",
    "value": "appuser"
  },
  {
    "key": "SMTP_HOST",
    "value": "x.x.x.x"
  },
  {
    "key": "SMTP_USERNAME",
    "value": "appuser"
  },
  {
    "key": "SMTP_PASSWORD",
    "value": "appuser"
  }
]
```