### PR TITLE
update dependency for thor gem

### DIFF
--- a/drive_env.gemspec
+++ b/drive_env.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "google_drive", "~> 3.0"
   spec.add_dependency "googleauth", "~> 0.5"
-  spec.add_dependency "thor", "~> 0.19"
+  spec.add_dependency "thor", "~> 1.0"
   spec.add_dependency "text-table", "~> 1.2"
 
   spec.add_development_dependency "bundler"

--- a/lib/drive_env/version.rb
+++ b/lib/drive_env/version.rb
@@ -1,3 +1,3 @@
 module DriveEnv
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end


### PR DESCRIPTION
I'm not sure this should be a final fix for the hazardous dependency journey, but rails 6.1.x has dependency thor ~> 1.0 and clearly conflict with drive_env-0.4.1. I will try to update the dependency of drive_env first.